### PR TITLE
Fix SB3 shimmy dependency

### DIFF
--- a/IBS_GitHub_Helper_Files/requirements.txt
+++ b/IBS_GitHub_Helper_Files/requirements.txt
@@ -4,6 +4,7 @@ matplotlib
 scikit-learn
 networkx
 gym
+shimmy>=2.0
 stable-baselines3
 streamlit
 fastapi

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# IBS Project 
+# IBS Project
+
+## Installation
+
+Install the Python requirements using pip:
+
+```bash
+pip install -r requirements.txt
+```
+
+If you plan to use Stable-Baselines3 with classic Gym environments, make sure the
+`shimmy` package is installed as SB3 now relies on Gymnasium internally:
+
+```bash
+pip install 'shimmy>=2.0'
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ matplotlib
 scikit-learn
 networkx
 gym
+shimmy>=2.0
 stable-baselines3
 streamlit
 fastapi


### PR DESCRIPTION
## Summary
- include `shimmy` in both requirement files
- document install instructions and note shimmy for SB3

## Testing
- `pip install -r requirements.txt` *(fails: ModuleNotFoundError for stable_baselines3)*

------
https://chatgpt.com/codex/tasks/task_e_6850cdab54dc832c830a4b9f1a709f9e